### PR TITLE
FEAT :: Resizing Fonts on Resolution Changes

### DIFF
--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -839,3 +839,15 @@ end
 function GM:ForceDermaSkin()
     return "Parallax"
 end
+
+function GM:OnScreenSizeChanged(oldWidth, oldHeight, newWidth, newHeight)
+    for k, v in ipairs(ax.gui) do
+        if ( IsValid(v) and ispanel(v) ) then
+            v:Remove()
+
+            -- Perhaps recreate the GUIs?
+        end
+    end
+
+    hook.Run("LoadFonts")
+end


### PR DESCRIPTION
This pull request adds a new hook to handle screen size changes in the `gamemode/core/hooks/cl_hooks.lua` file. The most important change involves introducing the `GM:OnScreenSizeChanged` function.

### New functionality:

* [`gamemode/core/hooks/cl_hooks.lua`](diffhunk://#diff-a13f4088e47c04543bc029f523f7335843a22a0e8794060d9437a8e7604c8f01R842-R853): Added the `GM:OnScreenSizeChanged` function, which removes valid GUI panels stored in `ax.gui` when the screen size changes and triggers the `LoadFonts` hook. This prepares the GUI for potential recreation and ensures fonts are updated appropriately.