### PR TITLE
IMPR :: Speed up ax.faction:Get

### DIFF
--- a/gamemode/core/libraries/shared/sh_faction.lua
+++ b/gamemode/core/libraries/shared/sh_faction.lua
@@ -133,15 +133,15 @@ function ax.faction:Get(identifier)
         end
 
         return self.instances[identifier]
-    end
+    elseif ( isstring(identifier) ) then
+        if ( self.stored[identifier] ) then
+            return self.stored[identifier]
+        end
 
-    if ( self.stored[identifier] ) then
-        return self.stored[identifier]
-    end
-
-    for k, v in ipairs(self.instances) do
-        if ( ax.util:FindString(v.Name, identifier) or ax.util:FindString(v.UniqueID, identifier) ) then
-            return v
+        for k, v in ipairs(self.instances) do
+            if ( ax.util:FindString(v.Name, identifier) or ax.util:FindString(v.UniqueID, identifier) ) then
+                return v
+            end
         end
     end
 


### PR DESCRIPTION
This pull request focuses on improving the efficiency and readability of faction-related functions in `sh_faction.lua`. The most significant changes involve replacing loops with direct indexing for performance optimization and simplifying the code structure.

### Performance improvements:

* [`sh_faction.lua`](diffhunk://#diff-112c3dedc1894157c0bc2eb73e0659b431eaf3b321d819ef36d1943e4994deffL106-R106): Replaced the `pairs` function with `ipairs` in the `Register` method to ensure proper iteration over numerically indexed tables. This change improves consistency and performance.
* [`sh_faction.lua`](diffhunk://#diff-112c3dedc1894157c0bc2eb73e0659b431eaf3b321d819ef36d1943e4994deffL135-R136): Updated the `Get` method to use direct indexing (`self.instances[identifier]`) instead of looping through all instances when the identifier is numeric. This change significantly improves lookup performance.

### Code simplification:

* [`sh_faction.lua`](diffhunk://#diff-112c3dedc1894157c0bc2eb73e0659b431eaf3b321d819ef36d1943e4994deffL135-R136): Removed unnecessary type conversion (`tonumber(identifier)`) and redundant loops in the `Get` method, simplifying the logic for retrieving factions. [[1]](diffhunk://#diff-112c3dedc1894157c0bc2eb73e0659b431eaf3b321d819ef36d1943e4994deffL135-R136) [[2]](diffhunk://#diff-112c3dedc1894157c0bc2eb73e0659b431eaf3b321d819ef36d1943e4994deffR146)

# Benchmark
```lua
local self = ax.faction
GMN.TestCompare(function()
    for k, v in ipairs(self:GetAll()) do
            if ( ax.util:FindString(v.ID, tonumber("2")) ) then
                return v
            end
        end
end, function()
    return self.instances[2]
end)
```

# Output
```
[GMN] Starting test..
1 JIT ON took 0.15375800000038 seconds to run 1000000 times, average: 1.5375800000038e-07 seconds
2 JIT ON took 0.010584999999992 seconds to run 1000000 times, average: 1.0584999999992e-08 seconds
1 JIT OFF took 0.33082879999984 seconds to run 1000000 times, average: 3.3082879999984e-07 seconds
2 JIT OFF took 0.0086836000000403 seconds to run 1000000 times, average: 8.6836000000403e-09 seconds
JIT ON 2 is 1352.603% faster than test 1
JIT OFF 2 is 3709.812% faster than test 1

```