### PR TITLE
IMPR :: aw.util:FindPlayer

### DIFF
--- a/gamemode/core/util.lua
+++ b/gamemode/core/util.lua
@@ -306,19 +306,25 @@ function ax.util:FindPlayer(identifier)
         return Player(identifier)
     end
 
-    if ( isstring(identifierType) ) then
-        for _, v in player.Iterator() do
-            if ( self:FindString(v:Name(), identifier) or self:FindString(v:SteamID(), identifier) or self:FindString(v:SteamID64(), identifier) ) then
-                return v
-            end
-        end
-    end
-
-    if ( self:FindString(identifierType, "table") ) then
+    if ( istable(identifier) ) then
         for k, v in ipairs(identifier) do
             local foundPlayer = self:FindPlayer(v)
             if ( foundPlayer ) then
                 return foundPlayer
+            end
+        end
+    end
+
+    if ( isstring(identifier) ) then
+        if (string.find(identifier, "STEAM_(%d+):(%d+):(%d+)")) then
+            return player.GetBySteamID(identifier)
+        elseif (string.find(identifier, "7656119%d+")) then
+            return player.GetBySteamID64(identifier)
+        end
+
+        for _, v in player.Iterator() do
+            if ( self:FindString(v:Name(), identifier) or self:FindString(v:SteamID(), identifier) or self:FindString(v:SteamID64(), identifier) ) then
+                return v
             end
         end
     end


### PR DESCRIPTION
This pull request refactors the `FindPlayer` function in `gamemode/core/util.lua` to improve clarity and functionality. The main changes include restructuring the logic for handling string and table identifiers and adding a specific check for SteamID and SteamID64 formats.

### Refactoring and functionality improvements:

* Replaced the check for `isstring(identifierType)` with a more appropriate placement and logic for `isstring(identifier)`, ensuring that string identifiers are processed with specific checks for SteamID and SteamID64 formats before iterating over players.
* Replaced the check for `self:FindString(identifierType, "table")` with `istable(identifier)` for better clarity and alignment with Lua conventions when handling table identifiers.