### PR TITLE
IMPR :: Colors

### DIFF
--- a/gamemode/core/libraries/shared/sh_colors.lua
+++ b/gamemode/core/libraries/shared/sh_colors.lua
@@ -33,13 +33,12 @@ end
 -- @return The color.
 function ax.color:Get(name)
     local storedColor = self.stored[name]
-    -- Copy ONLY if you intend to modify the color
     if ( IsColor(storedColor) ) then
         return setmetatable({r = storedColor.r, g = storedColor.g, b = storedColor.b, a = storedColor.a}, colorObject)
     end
 
     ax.util:PrintError("Attempted to get an invalid color!")
-    return false
+    return nil
 end
 
 --- Dims a color by a specified fraction.

--- a/gamemode/core/libraries/shared/sh_colors.lua
+++ b/gamemode/core/libraries/shared/sh_colors.lua
@@ -3,6 +3,7 @@
 
 ax.color = {}
 ax.color.stored = {}
+local colorObject = FindMetaTable("Color")
 
 --- Registers a new color.
 -- @realm shared
@@ -30,13 +31,11 @@ end
 -- @param name The name of the color.
 -- @param copy boolean Whether to return a copy of the color (default: false).
 -- @return The color.
-function ax.color:Get(name, copy)
-    if ( copy == nil ) then copy = false end
-
+function ax.color:Get(name)
     local storedColor = self.stored[name]
     -- Copy ONLY if you intend to modify the color
     if ( IsColor(storedColor) ) then
-        return copy and Color(storedColor.r, storedColor.g, storedColor.b, storedColor.a) or storedColor
+        return setmetatable({r = storedColor.r, g = storedColor.g, b = storedColor.b, a = storedColor.a}, colorObject)
     end
 
     ax.util:PrintError("Attempted to get an invalid color!")
@@ -48,7 +47,6 @@ end
 -- @param col Color The color to dim.
 -- @param frac number The fraction to dim the color by.
 -- @return Color The dimmed color.
-local colorObject = FindMetaTable("Color")
 function ax.color:Dim(col, frac)
     return setmetatable({r = col.r * frac, g = col.g * frac, b = col.b * frac, a = col.a}, colorObject)
 end

--- a/gamemode/core/libraries/shared/sh_colors.lua
+++ b/gamemode/core/libraries/shared/sh_colors.lua
@@ -52,7 +52,7 @@ function ax.color:Dim(col, frac)
 end
 
 if ( CLIENT ) then
-    concommand.Add("ax_list_colours", function(client, cmd, arguments)
+    concommand.Add("ax_list_colors", function(client, cmd, arguments)
         for k, v in pairs(ax.color.stored) do
             ax.util:Print("Color: " .. k .. " >> ", ax.color:Get("cyan"), v, " Color Sample")
         end

--- a/gamemode/core/libraries/shared/sh_colors.lua
+++ b/gamemode/core/libraries/shared/sh_colors.lua
@@ -29,7 +29,6 @@ end
 --- Gets a color by its name.
 -- @realm shared
 -- @param name The name of the color.
--- @param copy boolean Whether to return a copy of the color (default: false).
 -- @return The color.
 function ax.color:Get(name)
     local storedColor = self.stored[name]

--- a/gamemode/core/libraries/shared/sh_colors.lua
+++ b/gamemode/core/libraries/shared/sh_colors.lua
@@ -48,8 +48,9 @@ end
 -- @param col Color The color to dim.
 -- @param frac number The fraction to dim the color by.
 -- @return Color The dimmed color.
+local colorObject = FindMetaTable("Color")
 function ax.color:Dim(col, frac)
-    return Color(col.r * frac, col.g * frac, col.b * frac, col.a)
+    return setmetatable({r = col.r * frac, g = col.g * frac, b = col.b * frac, a = col.a}, colorObject)
 end
 
 if ( CLIENT ) then


### PR DESCRIPTION
This pull request refactors the `sh_colors.lua` library by replacing the use of the `Color` constructor with the `setmetatable` function to create color objects, ensuring they are associated with the `Color` metatable. The changes aim to improve code consistency and potentially optimize color handling.

### Refactoring of color handling:

* **Introduction of the `Color` metatable**: Added a local variable `colorObject` to store the `Color` metatable using `FindMetaTable("Color")`. This metatable is now used to create color objects. [gamemode/core/libraries/shared/sh_colors.luaR6](diffhunk://#diff-b3bf3b9ea8a50203883f706650a8b2b0bdb5de95129c090f6d211be80e1600beR6)
* **Refactored `ax.color:Get` method**: Replaced the `Color` constructor with `setmetatable` to create a color object with the `Color` metatable. This ensures consistency in how colors are handled. ([gamemode/core/libraries/shared/sh_colors.luaL33-R38](diffhunk://#diff-b3bf3b9ea8a50203883f706650a8b2b0bdb5de95129c090f6d211be80e1600beL33-R38))
* **Refactored `ax.color:Dim` method**: Updated the method to use `setmetatable` for creating dimmed color objects, associating them with the `Color` metatable. ([gamemode/core/libraries/shared/sh_colors.luaL52-R51](diffhunk://#diff-b3bf3b9ea8a50203883f706650a8b2b0bdb5de95129c090f6d211be80e1600beL52-R51))

* Benchmark
```lua
local colorMeta = FindMetaTable("Color")
local color = Color(20, 20, 20)
GMN.TestCompare(function()
    return setmetatable({r = color.r * 20, g = color.g * 20, b = color.b * 20}, colorMeta)
end, function()
    return Color(color.r * 20, color.g * 20, color.b * 20)
end)
```
Results:
```lua
[GMN] Starting test..
1 JIT ON took 0.00061610000011569 seconds to run 1000000 times, average: 6.1610000011569e-10 seconds
2 JIT ON took 0.00062100000104692 seconds to run 1000000 times, average: 6.2100000104692e-10 seconds
1 JIT OFF took 0.15771739999946 seconds to run 1000000 times, average: 1.5771739999946e-07 seconds
2 JIT OFF took 0.20970940000007 seconds to run 1000000 times, average: 2.0970940000007e-07 seconds
JIT ON 1 is 0.795% faster than test 2
JIT OFF 1 is 32.965% faster than test 2
```