### PR TITLE
Fix tooltip size

### DIFF
--- a/gamemode/core/ui/cl_tooltip.lua
+++ b/gamemode/core/ui/cl_tooltip.lua
@@ -58,7 +58,7 @@ function PANEL:SizeToContents()
         height = height + ax.util:GetTextHeight("parallax")
     end
 
-    self:SetSize(width + 32, height)
+    self:SetSize(width + 32, height + 8)
 end
 
 function PANEL:Think()


### PR DESCRIPTION
Fixes #33.

# Before && After && Different font

![image](https://github.com/user-attachments/assets/7c3e7568-8224-433c-b35b-68db37b9a64a)

![image](https://github.com/user-attachments/assets/7eddfb77-a59b-4088-8f76-9cc6e9e9b3d2)

![image](https://github.com/user-attachments/assets/a45f8f66-6b3e-45ea-9a2b-e545328fb9ae)
