### PR TITLE
fix(admin): restrict physgun pickup and simplify checks

### DIFF
--- a/gamemode/modules/admin/hooks/sv_hooks.lua
+++ b/gamemode/modules/admin/hooks/sv_hooks.lua
@@ -15,11 +15,9 @@ function MODULE:PlayerReady(client)
 end
 
 function MODULE:PhysgunPickup(client, entity)
-    if ( CAMI.PlayerHasAccess(client, "Parallax - Pickup Players", nil) != true ) then
-        return false
+    if ( CAMI.PlayerHasAccess(client, "Parallax - Pickup Players", nil) and ax.util:IsValidPlayer(entity) ) then
+        return true
     end
-
-    return true
 end
 
 function MODULE:OnPhysgunPickup(client, entity)
@@ -44,62 +42,46 @@ function MODULE:PlayerSpawnEffect(client, model)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Effects", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnNPC(client, npc, weapon)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn NPCs", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnProp(client, model)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Props", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnRagdoll(client, model)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Ragdolls", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnSENT(client, model)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn SENTs", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnSWEP(client, weapon, swep)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Weapons", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerGiveSWEP(client, weapon, spawnInfo)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Weapons", nil) != true ) then
         return false
     end
-
-    return true
 end
 
 function MODULE:PlayerSpawnVehicle(client, model, name, vehicleTable)
     if ( CAMI.PlayerHasAccess(client, "Parallax - Spawn Vehicles", nil) != true ) then
         return false
     end
-
-    return true
 end


### PR DESCRIPTION
## PR checklist (Style & Hygiene)

Tick all that apply. If something doesn’t apply, briefly explain why.

- [ ] camelCase locals/fields and SCREAMING_SNAKE_CASE constants
- [ ] PascalCase for functions/methods that are part of a public API
- [ ] Guard clauses preferred over deep nesting
- [X] One statement per line; spaces inside parentheses and around operators
- [ ] Hooks have named identifiers and delegate to named functions
- [X] No mystery globals; explicit `local` when possible
- [X] GLua operators used consistently (`!`, `!=`) where applicable
- [X] `IsValid()` used for entity validity checks
- [ ] Files are named using lower_snake_case.lua by realm when relevant (cl_/sh_/sv_)
- [ ] Public APIs include brief LDOC-style comments
- [X] Third-party code not modified (placed under `gamemode/framework/thirdparty/`)

I did just removed a bunch of redundant "return true" inside the admin module. Just to be sure that the hooks are acting to "restrict" and not to "override" derive gamemode/thirdparties default behaviors. Sorry for the first PR, I didn't do the right thing and tried to merge the entire staging into main, hopefully I noticed and closed to redo the PR properly.

Reference: `.github/STYLING.md`
